### PR TITLE
Change HTTP status codes of failure responses

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -1,6 +1,8 @@
 Django Rest Framework JWT 2FA Change Log
 ========================================
 
+* Change HTTP status codes of failure responses
+
 0.2.0 (Released 2018-02-07 12:30 +0200)
 ---------------------------------------
 

--- a/drf_jwt_2fa/exceptions.py
+++ b/drf_jwt_2fa/exceptions.py
@@ -1,0 +1,13 @@
+from django.utils.translation import ugettext_lazy as _
+from rest_framework import exceptions, status
+
+
+class VerificationCodeSendingFailed(exceptions.APIException):
+    status_code = status.HTTP_501_NOT_IMPLEMENTED
+    default_code = 'verification_code_sending_failed'
+    default_detail = _("Verification code sending failed: {reason}")
+
+    def __init__(self, reason, detail=None, code=None, *args, **kwargs):
+        super(VerificationCodeSendingFailed, self).__init__(
+            detail=(detail or self.default_detail.format(reason=reason)),
+            code=code, *args, **kwargs)

--- a/drf_jwt_2fa/serializers.py
+++ b/drf_jwt_2fa/serializers.py
@@ -1,6 +1,5 @@
 from django.contrib.auth import authenticate, get_user_model
-from django.utils.translation import ugettext as _
-from rest_framework import serializers
+from rest_framework import exceptions, serializers
 from rest_framework_jwt.compat import Serializer as JwtSerializer
 from rest_framework_jwt.serializers import PasswordField
 from rest_framework_jwt.settings import api_settings as jwt_settings
@@ -39,7 +38,7 @@ class CodeTokenSerializer(Jwt2faSerializer):
         }
         user = authenticate(**credentials)
         if not user:
-            raise serializers.ValidationError(_("Invalid credentials"))
+            raise exceptions.AuthenticationFailed()
         check_user_validity(user)
         return user
 
@@ -66,7 +65,7 @@ class AuthTokenSerializer(Jwt2faSerializer):
         try:
             user = user_model.objects.get_by_natural_key(username)
         except user_model.DoesNotExist:
-            raise serializers.ValidationError(_("Unknown user"))
+            raise exceptions.AuthenticationFailed()
         check_user_validity(user)
         return user
 

--- a/drf_jwt_2fa/tests/test_endpoints.py
+++ b/drf_jwt_2fa/tests/test_endpoints.py
@@ -43,9 +43,8 @@ def test_code_token_invalid_password():
     result = client.post(
         reverse('get-code'),
         data={'username': 'testuser', 'password': 'wrong'})
-    assert sorted(result.data.keys()) == ['non_field_errors']
-    assert result.status_code == status.HTTP_400_BAD_REQUEST
-    assert result.data['non_field_errors'] == ['Invalid credentials']
+    assert result.data == {'detail': 'Incorrect authentication credentials.'}
+    assert result.status_code == status.HTTP_403_FORBIDDEN
 
 
 class InactiveAllowingAuthBackend(ModelBackend):
@@ -64,9 +63,9 @@ def test_code_token_inactive_user():
     result = client.post(
         reverse('get-code'),
         data={'username': 'testuser', 'password': 'a42'})
-    assert sorted(result.data.keys()) == ['non_field_errors']
-    assert result.status_code == status.HTTP_400_BAD_REQUEST
-    assert result.data['non_field_errors'] == ['Deactivated user']
+    assert result.data == {
+        'detail': 'You do not have permission to perform this action.'}
+    assert result.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
@@ -92,9 +91,8 @@ def test_auth_token_invalid_code():
     result = client.post(
         reverse('auth'),
         data={'code_token': code_token, 'code': code})
-    assert sorted(result.data.keys()) == ['non_field_errors']
-    assert result.status_code == status.HTTP_400_BAD_REQUEST
-    assert result.data['non_field_errors'] == ['Verification failed']
+    assert result.data == {'detail': 'Incorrect authentication credentials.'}
+    assert result.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db
@@ -107,6 +105,5 @@ def test_auth_token_removed_user():
     result = client.post(
         reverse('auth'),
         data={'code_token': code_token, 'code': code})
-    assert sorted(result.data.keys()) == ['non_field_errors']
-    assert result.status_code == status.HTTP_400_BAD_REQUEST
-    assert result.data['non_field_errors'] == ['Unknown user']
+    assert result.data == {'detail': 'Incorrect authentication credentials.'}
+    assert result.status_code == status.HTTP_403_FORBIDDEN

--- a/drf_jwt_2fa/tests/test_throttling.py
+++ b/drf_jwt_2fa/tests/test_throttling.py
@@ -119,8 +119,9 @@ def test_code_token_throttling():
         frozen_datetime.tick(delta=datetime.timedelta(seconds=1))
         assert time.time() == 1577970001.0
         result0 = attempt(code_token1, incorrect_codes[0])
-        assert result0.data == {'non_field_errors': ['Verification failed']}
-        assert result0.status_code == status.HTTP_400_BAD_REQUEST
+        assert result0.data == {
+            'detail': 'Incorrect authentication credentials.'}
+        assert result0.status_code == status.HTTP_403_FORBIDDEN
 
         # Try 2 on code_token1, after 0.5s.  Should be throttled
         frozen_datetime.tick(delta=datetime.timedelta(seconds=0.5))
@@ -138,8 +139,9 @@ def test_code_token_throttling():
         frozen_datetime.tick(delta=datetime.timedelta(seconds=1.75))
         assert time.time() == 1577970003.25
         result2 = attempt(code_token1, incorrect_codes[2])
-        assert result2.data == {'non_field_errors': ['Verification failed']}
-        assert result2.status_code == status.HTTP_400_BAD_REQUEST
+        assert result2.data == {
+            'detail': 'Incorrect authentication credentials.'}
+        assert result2.status_code == status.HTTP_403_FORBIDDEN
 
         # Try 4 on code_token1, after 0.75s.  Should be throttled.
         frozen_datetime.tick(delta=datetime.timedelta(seconds=0.75))
@@ -150,8 +152,9 @@ def test_code_token_throttling():
         # Try with a different code token.  Should NOT be throttled.
         assert time.time() == 1577970004.0
         result4 = attempt(code_token2, incorrect_codes[4])
-        assert result4.data == {'non_field_errors': ['Verification failed']}
-        assert result4.status_code == status.HTTP_400_BAD_REQUEST
+        assert result4.data == {
+            'detail': 'Incorrect authentication credentials.'}
+        assert result4.status_code == status.HTTP_403_FORBIDDEN
 
         # Try without a code token.  Should NOT be throttled.
         assert time.time() == 1577970004.0
@@ -164,5 +167,6 @@ def test_code_token_throttling():
         frozen_datetime.tick(delta=datetime.timedelta(seconds=1.5))
         assert time.time() == 1577970005.5
         result5 = attempt(code_token1, incorrect_codes[5])
-        assert result5.data == {'non_field_errors': ['Verification failed']}
-        assert result5.status_code == status.HTTP_400_BAD_REQUEST
+        assert result5.data == {
+            'detail': 'Incorrect authentication credentials.'}
+        assert result5.status_code == status.HTTP_403_FORBIDDEN

--- a/drf_jwt_2fa/utils.py
+++ b/drf_jwt_2fa/utils.py
@@ -1,8 +1,7 @@
 import base64
 import hashlib
 
-from django.utils.translation import ugettext as _
-from rest_framework import serializers
+from rest_framework import exceptions
 
 
 def check_user_validity(user):
@@ -13,7 +12,7 @@ def check_user_validity(user):
     :rtype: None
     """
     if not user.is_active:
-        raise serializers.ValidationError(_("Deactivated user"))
+        raise exceptions.PermissionDenied()
 
 
 def _unpadded_encode(data, encoder=base64.b64encode):


### PR DESCRIPTION
Make it easier to distinguish different error conditions from each other
by using more appropriate HTTP status codes in the error responses.