### PR TITLE
serializers: Fix type signature of context param

### DIFF
--- a/drf_jwt_2fa/serializers.py
+++ b/drf_jwt_2fa/serializers.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from typing import Any, NamedTuple
 
 from django.contrib.auth import authenticate, get_user_model
@@ -110,7 +111,7 @@ class AuthTokenSerializer(Jwt2faSerializer):
 
 
 def _create_auth_tokens_for_user(
-    user: AbstractBaseUser, context: dict[str, Any]
+    user: AbstractBaseUser, context: Mapping[str, Any]
 ) -> dict[str, str]:
     token = _get_token_class().for_user(user)
     drf_request = context.get("request")


### PR DESCRIPTION
The context Serializer.context type changed from dict to Mapping in djangorestframework-stubs 3.17.0 [1].  Fix the type signature of the helper function accordingly.

[1] https://github.com/typeddjango/djangorestframework-stubs/pull/946