### PR TITLE
CI: Use pinned deps for most checks

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -10,13 +10,16 @@ on:
 jobs:
   tests:
     name: "Tests: Py${{matrix.python}}-Django${{matrix.django}}"
+    continue-on-error: ${{ matrix.django == 'LATEST' }}
     strategy:
       matrix:
-        python: ["3.12", "3.14", "3.15.0-alpha.8"]
-        django: ["3.2", "4.2", "5.2", "6.0"]
+        python: ["3.12", "3.14", "3.15.0-beta.1"]
+        django: ["3.2", "4.2", "5.2", "6.0", "LATEST"]
         exclude:
+          - {python: "3.12", django: "LATEST"}
+          - {python: "3.14", django: "LATEST"}
           - {python: "3.14", django: "3.2"}
-          - {python: "3.15.0-alpha.8", django: "3.2"}
+          - {python: "3.15.0-beta.1", django: "3.2"}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6

--- a/conftest.py
+++ b/conftest.py
@@ -44,8 +44,10 @@ def ensure_tox_env_is_correct():
             python_ver = parse_ver_str(part.removeprefix("py"))
             infos.append(check_python_version(python_ver))
         elif part.startswith("django"):
-            django_ver = parse_ver_str(part.removeprefix("django"))
-            infos.append(check_django_version(django_ver))
+            ver_part = part.removeprefix("django")
+            if ver_part != "LATEST":
+                django_ver = parse_ver_str(ver_part)
+                infos.append(check_django_version(django_ver))
         else:
             raise ValueError(f"Unknown part in Tox environment name: {part}")
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
     py312-django32
     py{312,314,315}-django{42,52}
     py{312,314,315}-django60
+    py315-djangoLATEST
 labels =
     check = lint, style, typing, uvlock, docrendering, deploycheck
 
@@ -29,17 +30,27 @@ setenv =
 commands =
     pytest {posargs:--cov=drf_jwt_2fa}
 
+[testenv:py315-djangoLATEST]
+constrain_package_deps = False
+setenv =
+    PYTHONPATH=.
+    UV_PRERELEASE=allow
+deps = django@https://github.com/django/django/archive/refs/heads/main.zip
+
 [testenv:lint]
+runner = uv-venv-lock-runner
 package = skip
 commands =
     ruff check {posargs}
 
 [testenv:style]
+runner = uv-venv-lock-runner
 package = skip
 commands =
     ruff format --check --diff {posargs}
 
 [testenv:typing]
+runner = uv-venv-lock-runner
 package = editable
 commands =
     mypy {posargs:.}
@@ -58,6 +69,7 @@ commands =
     ./render-text-docs {posargs:--check README.rst ChangeLog.rst}
 
 [testenv:deploycheck]
+runner = uv-venv-lock-runner
 package = wheel
 setenv =
     PYTHONPATH=.


### PR DESCRIPTION
Use the dependency versions pinned in uv.lock for the check testenvs defined in tox.ini (except docrendering) and add a new testenv named python315-djangoLATEST which will use latest available prerelease versions of the deps and gets django from GitHub.
